### PR TITLE
Private Repositories: Add accessToken parameter on checkUserIsCollaborator calls

### DIFF
--- a/app/new-issue/NewIssueCtrl.js
+++ b/app/new-issue/NewIssueCtrl.js
@@ -61,7 +61,7 @@ angular.module('it').controller('NewIssueCtrl', function($scope, $sce, $filter, 
 
   $scope.$watch('template.owner && template.repo && user.login', function() {
     if ($scope.template.owner && $scope.template.repo && $scope.user && $scope.user.login) {
-      GitHubService.checkUserIsCollaborator($scope.template.owner, $scope.template.repo, $scope.user.login).then(function(isCollaborator) {
+      GitHubService.checkUserIsCollaborator($scope.template.owner, $scope.template.repo, $scope.user.login, $scope.user.accessToken).then(function(isCollaborator) {
         $scope.isCollaborator = isCollaborator;
       });
     }

--- a/app/services/GitHubService.js
+++ b/app/services/GitHubService.js
@@ -11,7 +11,7 @@ angular.module('it').factory('GitHubService', function($q, $http, util) {
       });
     },
 
-    checkUserIsCollaborator: function(owner, repo, user) {
+    checkUserIsCollaborator: function(owner, repo, user, accessToken) {
       var deferred = $q.defer();
       var url = convertUrl('repos/{{owner}}/{{repo}}/collaborators/{{user}}', {
         owner: owner,
@@ -20,7 +20,10 @@ angular.module('it').factory('GitHubService', function($q, $http, util) {
       });
       $http({
         method: 'GET',
-        url: url
+        url: url,
+        params: {
+          access_token: accessToken
+        }
       }).success(function() {
         deferred.resolve(true);
       }).error(function() {

--- a/app/templates/TemplateCtrl.js
+++ b/app/templates/TemplateCtrl.js
@@ -17,7 +17,7 @@ angular.module('it').controller('TemplateCtrl', function($scope, $location, $sce
 
   function checkIfUserIsCollaborator() {
     if ($scope.template.owner && $scope.template.repo && $scope.user && $scope.user.login) {
-      GitHubService.checkUserIsCollaborator($scope.template.owner, $scope.template.repo, $scope.user.login).then(function(isCollaborator) {
+      GitHubService.checkUserIsCollaborator($scope.template.owner, $scope.template.repo, $scope.user.login, $scope.user.accessToken).then(function (isCollaborator) {
         $scope.isCollaborator = isCollaborator;
         if (!isCollaborator) {
           showCollabWarning();


### PR DESCRIPTION
I was getting warnings that I was not a collaborator to my private repositories; this commit fixes that.
