### PR TITLE
Templating for issues with labels

### DIFF
--- a/app/new-issue/NewIssueCtrl.js
+++ b/app/new-issue/NewIssueCtrl.js
@@ -25,6 +25,7 @@ angular.module('it').controller('NewIssueCtrl', function($scope, $sce, $filter, 
     $scope.issue = {
       title: '',
       comments: '',
+      labels: '',
       fields: fields
     };
     $scope.issueUrl = '';
@@ -73,6 +74,15 @@ angular.module('it').controller('NewIssueCtrl', function($scope, $sce, $filter, 
     return template + '\n\n' + $scope.issue.comments;
   }
 
+  function getLabels() {
+    if(!$scope.issue.labels | $scope.issue.labels.length == 0) {
+      // an empty string confuses github's API, we need to return an empty array
+      return [];
+    } else {
+      return $scope.issue.labels;
+    }
+  }
+
   function compileTitle(string) {
     return util.simpleCompile(string, {
       title: $scope.issue.title || ' '
@@ -96,6 +106,7 @@ angular.module('it').controller('NewIssueCtrl', function($scope, $sce, $filter, 
     return {
       title: compileTemplate(compileTitle($scope.template.titleTemplate)),
       body: getBody(),
+      labels: getLabels(),
       milestone: $scope.template.selectedMilestone
     }
   }

--- a/app/new-issue/new-issue.html
+++ b/app/new-issue/new-issue.html
@@ -34,6 +34,10 @@
           <label for="issue-title">Issue Title</label>
           <input type="text" class="form-control" id="issue-title" ng-model="issue.title">
         </div>
+        <div ng-if="template.labels" class="form-group">        
+          <label for="issue-labels">Issue Labels (comma-separated)</label>
+          <input type="text" class="form-control" id="issue-labels" ng-list="," ng-model="issue.labels">
+        </div>
         <div ng-repeat="field in issue.fields">
           <div class="form-group">
             <label for="field-{{$index}}">{{field.name}}</label>

--- a/app/services/GitHubService.js
+++ b/app/services/GitHubService.js
@@ -32,7 +32,7 @@ angular.module('it').factory('GitHubService', function($q, $http, util) {
       return deferred.promise;
     },
 
-    submitIssue: function(issue, accessToken, owner, repo) {
+    submitIssue: function(issue, accessToken, owner, repo) {      
       return $http({
         method: 'POST',
         url: convertUrl('repos/{{owner}}/{{repo}}/issues', {
@@ -45,6 +45,7 @@ angular.module('it').factory('GitHubService', function($q, $http, util) {
         data: {
           title: issue.title,
           body: issue.body,
+          labels: issue.labels,
           milestone: issue.milestone
         }
       });

--- a/app/services/TemplateService.js
+++ b/app/services/TemplateService.js
@@ -24,7 +24,7 @@ angular.module('it').factory('TemplateService', function($q, Firebase, util, _) 
   }
 
   var TemplateService = {
-    saveTemplate: function(template) {
+    saveTemplate: function(template) {            
       var owner = cleanOutboundReference(template.owner);
       var repo = cleanOutboundReference(template.repo);
       var name = cleanOutboundReference(template.name);

--- a/app/templates/TemplateCtrl.js
+++ b/app/templates/TemplateCtrl.js
@@ -102,7 +102,8 @@ angular.module('it').controller('TemplateCtrl', function($scope, $location, $sce
       copy: true,
       owner: $scope.template.owner,
       repo: $scope.template.repo,
-      name: $scope.template.name
+      name: $scope.template.name,
+      labels: $scope.template.labels
     });
   };
 

--- a/app/templates/template.html
+++ b/app/templates/template.html
@@ -31,6 +31,9 @@
           <label for="template-notes">Template Notes</label>
           <textarea class="form-control" id="template-notes" placeholder="ex. use this for documentation requests (optional, and markdown accepted)" ng-model="template.notes"></textarea>
         </div>
+        <div class="form-group">          
+          <input type="checkbox" id="template-submit-labels" ng-model="template.labels"><span class="margin-left-small">Issues created from this template can contain labels</span>
+        </div>
         <div class="form-group" ng-show="milestones">
           <label for="template-milestone">Template Milestone</label>
           <select id="template-milestones" class="form-control" ng-model="template.selectedMilestone" ng-options="item.number as item.title for item in milestones">


### PR DESCRIPTION
Added a checkbox in the template creation page, that enables it to submit issues with labels. The labels are entered in a textfield in the form of comma-separated values.

I can add some styling if you think my idea is OK.